### PR TITLE
Form wizard

### DIFF
--- a/mysite/unicorn/forms.py
+++ b/mysite/unicorn/forms.py
@@ -3,42 +3,39 @@ from .models import Article, Author, Tag
 from django.forms.formsets import BaseFormSet
 
 
-class ArticleForm(forms.ModelForm):
-
-    class Meta:
-        model = Article
-        fields = '__all__'
-
-
-class AuthorForm(forms.ModelForm):
-
-    class Meta:
-        model = Author
-        fields = ('first_name', 'last_name', 'bio', 'academic_year', 'school')
-
-
-class TagForm(forms.ModelForm):
+class TagForm1(forms.ModelForm):
 
     class Meta:
         model = Tag
-        fields = ('text',)
+        fields = ['text']
 
 
-class AuthorForm1(forms.Form):
-    first_name = forms.CharField(max_length=50)
-    last_name = forms.CharField(max_length=50)
+class TagForm2(forms.ModelForm):
+
+    class Meta:
+        model = Tag
+        fields = ['description']
 
 
-class AuthorForm2(forms.Form):
-    bio = forms.CharField(max_length=140)
+class AuthorForm1(forms.ModelForm):
+
+    class Meta:
+        model = Author
+        fields = ['first_name', 'last_name']
 
 
-class AuthorForm3(forms.Form):
-    academic_year = forms.IntegerField()
+class AuthorForm2(forms.ModelForm):
+
+    class Meta:
+        model = Author
+        fields = ['bio']
 
 
-class AuthorForm4(forms.Form):
-    school = forms.CharField(max_length=40)
+class AuthorForm3(forms.ModelForm):
+
+    class Meta:
+        model = Author
+        fields = ['academic_year', 'school']
 
 
 class ArticleForm1(forms.ModelForm):
@@ -60,7 +57,7 @@ class ArticleForm3(forms.Form):
         a = Author(first_name="Greatest", last_name="Ever")
         a.save()
     all_authors = Author.objects.all()
-    authors = forms.ModelChoiceField(queryset=all_authors)
+    authors = forms.ModelMultipleChoiceField(queryset=all_authors)
 
 
 class ArticleForm4(forms.ModelForm):
@@ -89,4 +86,4 @@ class ArticleForm7(forms.Form):
         t = Tag(text="uva")
         t.save()
     all_tags = Tag.objects.all()
-    tags = forms.ModelChoiceField(queryset=all_tags)
+    tags = forms.ModelMultipleChoiceField(queryset=all_tags)

--- a/mysite/unicorn/forms.py
+++ b/mysite/unicorn/forms.py
@@ -7,6 +7,7 @@ class ArticleForm(forms.ModelForm):
 
     class Meta:
         model = Article
+        fields = '__all__'
 
 
 class AuthorForm(forms.ModelForm):

--- a/mysite/unicorn/forms.py
+++ b/mysite/unicorn/forms.py
@@ -87,3 +87,63 @@ class ArticleForm7(forms.Form):
         t.save()
     all_tags = Tag.objects.all()
     tags = forms.ModelMultipleChoiceField(queryset=all_tags)
+
+
+class ArticleForm0(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['headline', 'abstract', 'copy', 'slug', 'status']
+        exclude = ['authors', 'tags']
+
+
+class AuthorForm0(forms.Form):
+    if (len(Author.objects.all()) == 0):
+        a = Author(last_name="Ever", first_name="Greatest")
+        a.save()
+    all_authors = Author.objects.all()
+    authors = forms.ModelMultipleChoiceField(
+        queryset=all_authors, required=False)
+
+    first_name = forms.CharField(max_length=50, required=False)
+    last_name = forms.CharField(max_length=50, required=False)
+    bio = forms.CharField(max_length=140, required=False)
+    academic_year = forms.IntegerField(required=False)
+    school = forms.CharField(max_length=40, required=False)
+
+    # Handles new author submission
+    def cleaned_data(self):
+        checkAuthor = self.cleaned_data.get('authors', '')
+        checkNewAuthor = self.cleaned_data.get('first_name', 'academic_year')
+
+        if not checkAuthor and not checkNewAuthor:
+            raise forms.ValidationError("You must enter an author")
+
+        if checkAuthor:
+            return checkAuthor
+        else:
+            return checkNewAuthor
+
+
+class TagForm0(forms.Form):
+    if (len(Tag.objects.all()) == 0):
+        t = Tag(text="uva")
+        t.save()
+    all_tags = Tag.objects.all()
+    tags = forms.ModelMultipleChoiceField(queryset=all_tags, required=False)
+
+    text = forms.SlugField(max_length=32, required=False)
+    description = forms.CharField(max_length=140, required=False)
+
+    # Handles new tag creation
+    def cleaned_data(self):
+        checkTag = self.cleaned_data.get('tags', '')
+        checkNewTag = self.cleaned_data.get('text', '')
+
+        if not checkTag and not checkNewTag:
+            raise forms.ValidationError("You must enter a tag")
+
+        if checkTag:
+            return checkTag
+        else:
+            return checkNewTag

--- a/mysite/unicorn/forms.py
+++ b/mysite/unicorn/forms.py
@@ -55,11 +55,12 @@ class ArticleForm2(forms.ModelForm):
         fields = ['abstract']
 
 
-class ArticleForm3(forms.ModelForm):
-
-    class Meta:
-        model = Article
-        fields = ['authors']
+class ArticleForm3(forms.Form):
+    if (len(Author.objects.all()) == 0):
+        a = Author(first_name="Greatest", last_name="Ever")
+        a.save()
+    all_authors = Author.objects.all()
+    authors = forms.ModelChoiceField(queryset=all_authors)
 
 
 class ArticleForm4(forms.ModelForm):
@@ -83,8 +84,9 @@ class ArticleForm6(forms.ModelForm):
         fields = ['status']
 
 
-class ArticleForm7(forms.ModelForm):
-
-    class Meta:
-        model = Article
-        fields = ['tags']
+class ArticleForm7(forms.Form):
+    if (len(Tag.objects.all()) == 0):
+        t = Tag(text="uva")
+        t.save()
+    all_tags = Tag.objects.all()
+    tags = forms.ModelChoiceField(queryset=all_tags)

--- a/mysite/unicorn/forms.py
+++ b/mysite/unicorn/forms.py
@@ -21,3 +21,69 @@ class TagForm(forms.ModelForm):
     class Meta:
         model = Tag
         fields = ('text',)
+
+
+class AuthorForm1(forms.Form):
+    first_name = forms.CharField(max_length=50)
+    last_name = forms.CharField(max_length=50)
+
+
+class AuthorForm2(forms.Form):
+    bio = forms.CharField(max_length=140)
+
+
+class AuthorForm3(forms.Form):
+    academic_year = forms.IntegerField()
+
+
+class AuthorForm4(forms.Form):
+    school = forms.CharField(max_length=40)
+
+
+class ArticleForm1(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['headline']
+
+
+class ArticleForm2(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['abstract']
+
+
+class ArticleForm3(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['authors']
+
+
+class ArticleForm4(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['copy']
+
+
+class ArticleForm5(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['slug']
+
+
+class ArticleForm6(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['status']
+
+
+class ArticleForm7(forms.ModelForm):
+
+    class Meta:
+        model = Article
+        fields = ['tags']

--- a/mysite/unicorn/models.py
+++ b/mysite/unicorn/models.py
@@ -43,5 +43,15 @@ class Article(models.Model):
     status = models.CharField(max_length=15)
     tags = models.ManyToManyField(Tag, related_name='articles')
 
+    def add_authors(self, author_list):
+        for a in author_list:
+            self.authors.add(a)
+        self.save()
+
+    def add_tags(self, tag_list):
+        for t in tag_list:
+            self.tags.add(t)
+        self.save()
+
     class Meta:
         ordering = ('created',)

--- a/mysite/unicorn/models.py
+++ b/mysite/unicorn/models.py
@@ -43,14 +43,21 @@ class Article(models.Model):
     status = models.CharField(max_length=15)
     tags = models.ManyToManyField(Tag, related_name='articles')
 
+
+    def add_author(self, new_author):
+        self.authors.add(new_author)
+
+    def add_tag(self, new_tag):
+        self.tags.add(new_tag)
+
     def add_authors(self, author_list):
         for a in author_list:
-            self.authors.add(a)
+            self.add_author(a)
         self.save()
 
     def add_tags(self, tag_list):
         for t in tag_list:
-            self.tags.add(t)
+            self.add_tag(t)
         self.save()
 
     class Meta:

--- a/mysite/unicorn/templates/unicorn/article_form.html
+++ b/mysite/unicorn/templates/unicorn/article_form.html
@@ -1,0 +1,25 @@
+<h2>New Article</h2>
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+{% for field in form %}
+	{{field.error}}
+{% endfor %}
+
+<form action="/unicorn/article" method="post">{% csrf_token %}
+<table>
+	{{ wizard.management_form }}
+	{% if wizard.form.forms %}
+		{{ wizard.form.management_form }}
+		{% for form in wizard.form.forms %}
+			{{ form }}
+		{% endfor %}
+	{% else %}
+		{{ wizard.form }}
+	{% endif %}
+</table>
+{% if wizard.steps.prev %}
+<button name="wizard_goto_step" type="submit" value="{{wizard.steps.first}}">"first step"</button>
+<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">"prev step"</button>
+{% endif %}
+
+<input type="submit" value="Submit"/>
+</form>

--- a/mysite/unicorn/templates/unicorn/author_form.html
+++ b/mysite/unicorn/templates/unicorn/author_form.html
@@ -16,10 +16,9 @@
 		{{ wizard.form }}
 	{% endif %}
 </table>
+<input type="submit" value="Submit"/>
 {% if wizard.steps.prev %}
 <button name="wizard_goto_step" type="submit" value="{{wizard.steps.first}}">"first step"</button>
 <button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">"prev step"</button>
 {% endif %}
-
-<input type="submit" value="Submit"/>
 </form>

--- a/mysite/unicorn/templates/unicorn/author_form.html
+++ b/mysite/unicorn/templates/unicorn/author_form.html
@@ -1,0 +1,25 @@
+<h2>New Author</h2>
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+{% for field in form %}
+	{{field.error}}
+{% endfor %}
+
+<form action="/unicorn/author" method="post">{% csrf_token %}
+<table>
+	{{ wizard.management_form }}
+	{% if wizard.form.forms %}
+		{{ wizard.form.management_form }}
+		{% for form in wizard.form.forms %}
+			{{ form }}
+		{% endfor %}
+	{% else %}
+		{{ wizard.form }}
+	{% endif %}
+</table>
+{% if wizard.steps.prev %}
+<button name="wizard_goto_step" type="submit" value="{{wizard.steps.first}}">"first step"</button>
+<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">"prev step"</button>
+{% endif %}
+
+<input type="submit" value="Submit"/>
+</form>

--- a/mysite/unicorn/templates/unicorn/done.html
+++ b/mysite/unicorn/templates/unicorn/done.html
@@ -1,0 +1,24 @@
+{# Load the tag library #}
+{% load bootstrap3 %}
+
+{# Load CSS and JavaScript #}
+{% bootstrap_css %}
+{% bootstrap_javascript %}
+
+{# Display django.contrib.messages as Bootstrap alerts #}
+{% bootstrap_messages %}
+
+
+{% block content %}
+
+<h2>Success!</h2>
+make a cooler done page
+<br />
+{% for form in form_data %}
+{{form}}
+{% endfor %}
+
+<br />
+<button type="submit" class="save btn btn-default"><a href="{% url 'dashboard' %}">Home</a></button>
+
+{% endblock %}

--- a/mysite/unicorn/templates/unicorn/new_article.html
+++ b/mysite/unicorn/templates/unicorn/new_article.html
@@ -1,0 +1,24 @@
+<h2>New Article Wizard</h2>
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+{% for field in form %}
+	{{field.error}}
+{% endfor %}
+
+<form action="/unicorn/new" method="post">{% csrf_token %}
+<table>
+	{{ wizard.management_form }}
+	{% if wizard.form.forms %}
+		{{ wizard.form.management_form }}
+		{% for form in wizard.form.forms %}
+			{{ form }}
+		{% endfor %}
+	{% else %}
+		{{ wizard.form }}
+	{% endif %}
+</table>
+<input type="submit" value="Submit"/>
+{% if wizard.steps.prev %}
+<button name="wizard_goto_step" type="submit" value="{{wizard.steps.first}}">"first step"</button>
+<button name="wizard_goto_step" type="submit" value="{{ wizard.steps.prev }}">"prev step"</button>
+{% endif %}
+</form>

--- a/mysite/unicorn/templates/unicorn/tag_form.html
+++ b/mysite/unicorn/templates/unicorn/tag_form.html
@@ -1,10 +1,10 @@
-<h2>New Article</h2>
+<h2>New Tag</h2>
 <p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
 {% for field in form %}
 	{{field.error}}
 {% endfor %}
 
-<form action="/unicorn/article" method="post">{% csrf_token %}
+<form action="/unicorn/tag" method="post">{% csrf_token %}
 <table>
 	{{ wizard.management_form }}
 	{% if wizard.form.forms %}

--- a/mysite/unicorn/tests.py
+++ b/mysite/unicorn/tests.py
@@ -32,6 +32,7 @@ class ArticleFormTests(TestCase):
         form = ArticleForm2(data=form_data2)
         self.assertTrue(form.is_valid())
 
+    # TODO: Mock Many-to-Many relationships to validate a form
     # def test_article_form3_is_valid(self):
     #     author1 = Author(first_name="foo", last_name="bar")
     #     form_data3 = {'authors': author1}
@@ -53,6 +54,7 @@ class ArticleFormTests(TestCase):
         form = ArticleForm6(data=form_data6)
         self.assertTrue(form.is_valid())
 
+    # TODO: Mock Many-to-Many relationships to validate a form
     # def test_article_form6_is_valid(self):
     #     tag1 = Tag(text="text", description="description")
     #     form_data7 = {'tags': tag1}

--- a/mysite/unicorn/tests.py
+++ b/mysite/unicorn/tests.py
@@ -1,3 +1,25 @@
 from django.test import TestCase
+from .forms import *
 
-# Create your tests here.
+
+class AuthorFormTests(TestCase):
+
+    def test_author_form1_is_valid(self):
+        form_data1 = {'first_name': u'foo', 'last_name': u'bar'}
+        form = AuthorForm1(data=form_data1)
+        self.assertTrue(form.is_valid())
+
+    def test_author_form2_is_valid(self):
+        form_data2 = {'bio': u'baz'}
+        form = AuthorForm2(data=form_data2)
+        self.assertTrue(form.is_valid())
+
+    def test_author_form3_is_valid(self):
+        form_data3 = {'academic_year': 2016}
+        form = AuthorForm3(data=form_data3)
+        self.assertTrue(form.is_valid())
+
+    def test_author_form4_is_valid(self):
+        form_data4 = {'school': u'seas'}
+        form = AuthorForm4(data=form_data4)
+        self.assertTrue(form.is_valid())

--- a/mysite/unicorn/tests.py
+++ b/mysite/unicorn/tests.py
@@ -5,21 +5,69 @@ from .forms import *
 class AuthorFormTests(TestCase):
 
     def test_author_form1_is_valid(self):
-        form_data1 = {'first_name': u'foo', 'last_name': u'bar'}
+        form_data1 = {'first_name': u'Greatest', 'last_name': u'Ever'}
         form = AuthorForm1(data=form_data1)
         self.assertTrue(form.is_valid())
 
     def test_author_form2_is_valid(self):
-        form_data2 = {'bio': u'baz'}
+        form_data2 = {'bio': u'The Six'}
         form = AuthorForm2(data=form_data2)
         self.assertTrue(form.is_valid())
 
     def test_author_form3_is_valid(self):
-        form_data3 = {'academic_year': 2016}
+        form_data3 = {'academic_year': 2016, 'school': u'Ontario'}
         form = AuthorForm3(data=form_data3)
         self.assertTrue(form.is_valid())
 
-    def test_author_form4_is_valid(self):
-        form_data4 = {'school': u'seas'}
-        form = AuthorForm4(data=form_data4)
+
+class ArticleFormTests(TestCase):
+
+    def test_article_form1_is_valid(self):
+        form_data1 = {'headline': u'Honey'}
+        form = ArticleForm1(data=form_data1)
+        self.assertTrue(form.is_valid())
+
+    def test_article_form2_is_valid(self):
+        form_data2 = {'abstract': u'Nut'}
+        form = ArticleForm2(data=form_data2)
+        self.assertTrue(form.is_valid())
+
+    # def test_article_form3_is_valid(self):
+    #     author1 = Author(first_name="foo", last_name="bar")
+    #     form_data3 = {'authors': author1}
+    #     form = ArticleForm3(data=form_data3)
+    #     self.assertTrue(form.is_valid())
+
+    def test_article_form4_is_valid(self):
+        form_data4 = {'copy': u'copypasta'}
+        form = ArticleForm4(data=form_data4)
+        self.assertTrue(form.is_valid())
+
+    def test_article_form5_is_valid(self):
+        form_data5 = {'slug': u'slug'}
+        form = ArticleForm5(data=form_data5)
+        self.assertTrue(form.is_valid())
+
+    def test_article_form6_is_valid(self):
+        form_data6 = {'status': u'status'}
+        form = ArticleForm6(data=form_data6)
+        self.assertTrue(form.is_valid())
+
+    # def test_article_form6_is_valid(self):
+    #     tag1 = Tag(text="text", description="description")
+    #     form_data7 = {'tags': tag1}
+    #     form = ArticleForm7(data=form_data7)
+    #     self.assertTrue(form.is_valid())
+
+
+def TagFormTests(TestCase):
+
+    def test_tag_form1_is_valid(self):
+        form_data1 = {'text': u'it\'s'}
+        form = TagForm1(data=form_data1)
+        self.assertTrue(form.is_valid())
+
+    def test_tag_form2_is_valid(self):
+        form_data2 = {'description': u'1am'}
+        form = TagForm2(data=form_data)
         self.assertTrue(form.is_valid())

--- a/mysite/unicorn/urls.py
+++ b/mysite/unicorn/urls.py
@@ -3,14 +3,15 @@ from django.conf.urls import url
 from . import views
 
 from .forms import *
-from .views import AuthorWizard, ArticleWizard
+from .views import AuthorWizard, ArticleWizard, TagWizard
 
 urlpatterns = [
     url(r'^$', views.articleList, name='Article List'),
     url(r'^dash$', views.dashboard, name='dashboard'),
     url(r'^(?P<slug>[\w-]+)/$', views.articleDetail, name='detail'),
     url(r'^author$', AuthorWizard.as_view(
-        [AuthorForm1, AuthorForm2, AuthorForm3, AuthorForm4])),
+        [AuthorForm1, AuthorForm2, AuthorForm3])),
     url(r'^article$', ArticleWizard.as_view(
         [ArticleForm1, ArticleForm2, ArticleForm3, ArticleForm4, ArticleForm5, ArticleForm6, ArticleForm7])),
+    url(r'^tag$', TagWizard.as_view([TagForm1, TagForm2]))
 ]

--- a/mysite/unicorn/urls.py
+++ b/mysite/unicorn/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from . import views
 
 from .forms import *
-from .views import AuthorWizard, ArticleWizard, TagWizard
+from .views import AuthorWizard, ArticleWizard, TagWizard, NewArticleWizard
 
 urlpatterns = [
     url(r'^$', views.articleList, name='Article List'),
@@ -13,5 +13,7 @@ urlpatterns = [
         [AuthorForm1, AuthorForm2, AuthorForm3])),
     url(r'^article$', ArticleWizard.as_view(
         [ArticleForm1, ArticleForm2, ArticleForm3, ArticleForm4, ArticleForm5, ArticleForm6, ArticleForm7])),
-    url(r'^tag$', TagWizard.as_view([TagForm1, TagForm2]))
+    url(r'^tag$', TagWizard.as_view([TagForm1, TagForm2])),
+    url(r'^new$', NewArticleWizard.as_view(
+        [ArticleForm0, AuthorForm0, TagForm0])),
 ]

--- a/mysite/unicorn/urls.py
+++ b/mysite/unicorn/urls.py
@@ -12,5 +12,5 @@ urlpatterns = [
     url(r'^author$', AuthorWizard.as_view(
         [AuthorForm1, AuthorForm2, AuthorForm3, AuthorForm4])),
     url(r'^article$', ArticleWizard.as_view(
-        [ArticleForm1, ArticleForm2, ArticleForm4, ArticleForm5, ArticleForm6])),
+        [ArticleForm1, ArticleForm2, ArticleForm3, ArticleForm4, ArticleForm5, ArticleForm6, ArticleForm7])),
 ]

--- a/mysite/unicorn/urls.py
+++ b/mysite/unicorn/urls.py
@@ -2,8 +2,15 @@ from django.conf.urls import url
 
 from . import views
 
+from .forms import *
+from .views import AuthorWizard, ArticleWizard
+
 urlpatterns = [
     url(r'^$', views.articleList, name='Article List'),
     url(r'^dash$', views.dashboard, name='dashboard'),
     url(r'^(?P<slug>[\w-]+)/$', views.articleDetail, name='detail'),
+    url(r'^author$', AuthorWizard.as_view(
+        [AuthorForm1, AuthorForm2, AuthorForm3, AuthorForm4])),
+    url(r'^article$', ArticleWizard.as_view(
+        [ArticleForm1, ArticleForm2, ArticleForm4, ArticleForm5, ArticleForm6])),
 ]

--- a/mysite/unicorn/views.py
+++ b/mysite/unicorn/views.py
@@ -57,6 +57,27 @@ def flatten_dict(form_list):
     return flattened_form_data
 
 
+def getNewAuthor(data):
+    new_author = Author(
+        first_name=data['first_name'],
+        last_name=data['last_name'],
+        bio=data['bio'],
+        academic_year=data['academic_year'],
+        school=data['school'],
+    )
+    new_author.save()
+    return new_author
+
+
+def getNewTag(data):
+    new_tag = Tag(
+        text=data['text'],
+        description=data['description'],
+    )
+    new_tag.save()
+    return new_tag
+
+
 class AuthorWizard(SessionWizardView):
     template_name = "unicorn/author_form.html"
 
@@ -98,4 +119,34 @@ class TagWizard(SessionWizardView):
             description=form_data[1]['description'],
         )
         new_tag.save()
+        return render_to_response('unicorn/done.html', {'form_data': form_data})
+
+
+class NewArticleWizard(SessionWizardView):
+    template_name = "unicorn/new_article.html"
+
+    def done(self, form_list, **kwargs):
+        form_data = process_form_data(form_list)
+        article_data = flatten_dict(form_data)
+        new_article = Article(
+            headline=article_data['headline'],
+            abstract=article_data['abstract'],
+            copy=article_data['copy'],
+            slug=article_data['slug'],
+            status=article_data['status'],
+        )
+        # Must save parent object before adding m2m relationships
+        new_article.save()
+
+        new_article.add_authors(article_data['authors'])
+        if (len(article_data['first_name']) > 0 and len(article_data['last_name']) > 0):
+            new_author = getNewAuthor(article_data)
+            new_article.add_author(new_author)
+
+        new_article.add_tags(article_data['tags'])
+        if (len(article_data['text']) > 0 and len(article_data['description']) > 0):
+            new_tag = getNewTag(article_data)
+            new_article.add_tag(new_tag)
+
+        new_article.save()
         return render_to_response('unicorn/done.html', {'form_data': form_data})

--- a/mysite/unicorn/views.py
+++ b/mysite/unicorn/views.py
@@ -49,12 +49,12 @@ def process_form_data(form_list):
     form_data = [form.cleaned_data for form in form_list]
     return form_data
 
+
 def flatten_dict(form_list):
     flattened_form_data = {}
     for elem in form_list:
         flattened_form_data.update(elem)
     return flattened_form_data
-
 
 
 class AuthorWizard(SessionWizardView):
@@ -75,11 +75,11 @@ class ArticleWizard(SessionWizardView):
         form_data = process_form_data(form_list)
         article_data = flatten_dict(form_data)
         new_article = Article(
-                headline=article_data['headline'],
-                abstract=article_data['abstract'],
-                copy=article_data['copy'],
-                slug=article_data['slug'],
-            )
+            headline=article_data['headline'],
+            abstract=article_data['abstract'],
+            copy=article_data['copy'],
+            slug=article_data['slug'],
+        )
         # Must save parent object before adding m2m relationships
         new_article.save()
         new_article.add_authors(article_data['authors'])
@@ -87,14 +87,15 @@ class ArticleWizard(SessionWizardView):
         new_article.save()
         return render_to_response('unicorn/done.html', {'form_data': form_data})
 
+
 class TagWizard(SessionWizardView):
     template_name = "unicorn/tag_form.html"
 
     def done(self, form_list, **kwargs):
         form_data = process_form_data(form_list)
         new_tag = Tag(
-                text=form_data[0]['text'],
-                description=form_data[1]['description'],
-            )
+            text=form_data[0]['text'],
+            description=form_data[1]['description'],
+        )
         new_tag.save()
         return render_to_response('unicorn/done.html', {'form_data': form_data})

--- a/mysite/unicorn/views.py
+++ b/mysite/unicorn/views.py
@@ -1,7 +1,9 @@
 from .models import Article, Author, Tag
 from django.forms import modelformset_factory
 
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, render, render_to_response
+
+from formtools.wizard.views import SessionWizardView
 
 
 def articleList(request):
@@ -38,6 +40,27 @@ def dashboard(request):
         authorformset = AuthorFormSet()
         tagformset = TagFormSet()
     return render(request, 'unicorn/new.html',
-                 {'articleformset': articleformset,
-                        'authorformset': authorformset,
-                        'tagformset': tagformset})
+                  {'articleformset': articleformset,
+                   'authorformset': authorformset,
+                   'tagformset': tagformset})
+
+
+def process_form_data(form_list):
+    form_data = [form.cleaned_data for form in form_list]
+    return form_data
+
+
+class AuthorWizard(SessionWizardView):
+    template_name = "unicorn/author_form.html"
+
+    def done(self, form_list, **kwargs):
+        form_data = process_form_data(form_list)
+        return render_to_response('unicorn/done.html', {'form_data': form_data})
+
+
+class ArticleWizard(SessionWizardView):
+    template_name = "unicorn/article_form.html"
+
+    def done(self, form_list, **kwargs):
+        form_data = process_form_data(form_list)
+        return render_to_response('unicorn/done.html', {'form_data': form_data})

--- a/mysite/unicorn/views.py
+++ b/mysite/unicorn/views.py
@@ -74,7 +74,6 @@ class ArticleWizard(SessionWizardView):
     def done(self, form_list, **kwargs):
         form_data = process_form_data(form_list)
         article_data = flatten_dict(form_data)
-        print(article_data)
         new_article = Article(
                 headline=article_data['headline'],
                 abstract=article_data['abstract'],
@@ -93,7 +92,9 @@ class TagWizard(SessionWizardView):
 
     def done(self, form_list, **kwargs):
         form_data = process_form_data(form_list)
-        tag_data = flatten_dict(form_list)
-        new_tag = Tag(**tag_data)
+        new_tag = Tag(
+                text=form_data[0]['text'],
+                description=form_data[1]['description'],
+            )
         new_tag.save()
         return render_to_response('unicorn/done.html', {'form_data': form_data})


### PR DESCRIPTION
Adds step based forms for creating new articles, authors, and tags

Changes
- [ ] Individual forms for every step of creating a new article/author/tag
- [ ] Wizards to handle the collected form data
- [ ] New url routes
- [ ] Templates for the form wizard
- [ ] Simple form tests

Notes
- Needed to save an article before adding author and tag fields - m2m relationships need a parent object before being saved
