### PR TITLE
adding serialization for many to many fields

### DIFF
--- a/mysite/unicorn/models.py
+++ b/mysite/unicorn/models.py
@@ -24,9 +24,8 @@ class Tag(models.Model):
     slug = models.SlugField(max_length=32, unique=True)
     description = models.CharField(max_length=140, default="")
 
-    def __str__(self):
-        return '{slug}'.format(
-            slug=self.slug)
+    def __unicode__(self):
+        return '%s: %s' % (self.slug, self.description)
 
     class Meta:
         ordering = ('slug',)

--- a/mysite/unicorn_api/serializers.py
+++ b/mysite/unicorn_api/serializers.py
@@ -8,16 +8,19 @@ class AuthorSerializer(serializers.ModelSerializer):
         model = Author
 
 
+class TagSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Tag
+
+
 class ArticleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Article
 
-
-class TagSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Tag
+    tags = TagSerializer(many=True)
+    authors = AuthorSerializer(many=True)
 
 
 class ArticleImageSerializer(serializers.ModelSerializer):

--- a/mysite/unicorn_api/tests.py
+++ b/mysite/unicorn_api/tests.py
@@ -35,7 +35,7 @@ class GetArticleTest(APITestCase):
     def setUp(self):
         tag_data = {
             "description": "This is a test.",
-            "text": "helloworld"
+            "slug": "helloworld"
         }
         article_image_data = {
             "description": "helloworld",
@@ -81,7 +81,7 @@ class GetTagTest(APITestCase):
 
     def setUp(self):
         data = {
-            "text": "helloworld",
+            "slug": "helloworld",
             "description": "This is a test"
         }
         self.tag = Tag(**data)

--- a/mysite/unicorn_api/urls.py
+++ b/mysite/unicorn_api/urls.py
@@ -34,7 +34,7 @@ article_image_detail = views.ArticleImageViewSet.as_view({
 })
 
 urlpatterns = [
-    url(r'^', views.schema_view),
+    url(r'^$', views.schema_view),
     url(r'^authors/$', author_list, name='author-list'),
     url(r'^authors/(?P<pk>[-\w]+)/$', author_detail, name='author-detail'),
     url(r'^articles/$', article_list, name='article-list'),


### PR DESCRIPTION
This makes the schema view for an article more robust because it shows the fields of its manytomany fields instead of just their ID.