### PR TITLE
Changing the maximum length of the charfield for author's school

### DIFF
--- a/mysite/unicorn/models.py
+++ b/mysite/unicorn/models.py
@@ -24,7 +24,7 @@ class Author(models.Model):
         ("NURSE", "School of Nursing"),
     )
     school = models.CharField(
-        max_length=1,
+        max_length=100,
         choices=SCHOOL_CHOICES)
 
     def __str__(self):


### PR DESCRIPTION
The previous max length was 1, which needed to be changed since all of the school name strings are >1 character.